### PR TITLE
whitelist searx.space stats service

### DIFF
--- a/example.toml
+++ b/example.toml
@@ -6,7 +6,7 @@ MAX_RETRY = 5
 PORT = 3000
 TARGET = '127.0.0.1:8888'
 TIMEOUT_LOAD = 120
-WHITELIST = ['8.8.8.8', '1.1.1.1']
+WHITELIST = ['8.8.8.8', '1.1.1.1', '176.31.252.227', '2001:41d0:8:de3::1']
 
 [WHITELIST_PAGES]
 GET = ['^/$', '^/autocompleter(.*)$', '^/favicon.ico$', '^/about$', '^/robots.txt$', '^/opensearch.xml$']


### PR DESCRIPTION
[searx.space](https://searx.space/) is a great tool to see the score of `searx` instances.